### PR TITLE
DOPS-10649: app-controlled ivysettings

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -77,13 +77,20 @@ echo -n "-----> Installing ivysettings.xml....."
 if [ -f .ivy2/ivysettings.xml ]; then
   rm .ivy2/ivysettings.xml
 fi
+
 mkdir -p .ivy2
-PLAY_SETTINGS_URL="http://s3.amazonaws.com/heroku-jvm-langpack-play/ivysettings.xml"
-CREDS=$(echo '  <credentials host="maven.lendup.com" realm="closed site" username="${LENDUP_MAVEN_REPO_USER}" passwd="${LENDUP_MAVEN_REPO_PW}"/>' \
-  | perl -p -e 's/\$\{([^}]+)\}/defined $ENV{$1} ? $ENV{$1} : $&/eg; s/\$\{([^}]+)\}//eg')
-# NOTE: If testing on mac: brew install gnu-sed; alias sed=gsed
-curl --silent --max-time 10 --location $PLAY_SETTINGS_URL | sed "/<ivysettings>/ a ${CREDS}" > .ivy2/ivysettings.xml
-echo " done"
+
+if [[ -e "conf/ivysettings.xml" ]] ; then
+  # If the app has its own ivysettings.xml, use that.
+  cp conf/ivysettings.xml .ivy2/.
+else
+  PLAY_SETTINGS_URL="http://s3.amazonaws.com/heroku-jvm-langpack-play/ivysettings.xml"
+  CREDS=$(echo '  <credentials host="maven.lendup.com" realm="closed site" username="${LENDUP_MAVEN_REPO_USER}" passwd="${LENDUP_MAVEN_REPO_PW}"/>' \
+    | perl -p -e 's/\$\{([^}]+)\}/defined $ENV{$1} ? $ENV{$1} : $&/eg; s/\$\{([^}]+)\}//eg')
+  # NOTE: If testing on mac: brew install gnu-sed; alias sed=gsed
+  curl --silent --max-time 10 --location $PLAY_SETTINGS_URL | sed "/<ivysettings>/ a ${CREDS}" > .ivy2/ivysettings.xml
+  echo " done"
+fi
 
 
 # ---------- GULP SHITZ --------------


### PR DESCRIPTION
Best viewed with [`?w=1`](18/files?w=1)

cc @jakeyr @teddywilson @acrao @lumengxi @rahulkapur @vudayas 

any other heroku/buildpack experts? please ping them

Anyway, the plan is to check in a `conf/ivysettings.xml` into LDC that will slurp in the appropriate env vars for artifactory. eventually we can remove this curl+perl stuff.